### PR TITLE
errorprone anotation dependenci missing fixes

### DIFF
--- a/nativetemplates/build.gradle
+++ b/nativetemplates/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation 'com.google.android.gms:play-services-ads:20.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'com.google.errorprone:error_prone_annotations:2.9.0'
 }


### PR DESCRIPTION
I have tried to use this template few months back and I found an issue that **errorprone anotation dependenci** was missing from the gradle file. It kill my time to find the right dependency to fix this issue. And Today when I'm again try to implement native ad's I have face same issue. So I fix it and make a pull request. Hope so you will review and accept it to solve the problem. 

Thank You😁