### PR TITLE
Update rating bar style and add error prone dependency

### DIFF
--- a/nativetemplates/build.gradle
+++ b/nativetemplates/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation 'com.google.android.gms:play-services-ads:20.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'com.google.errorprone:error_prone_annotations:2.16'
 }

--- a/nativetemplates/src/main/res/layout/gnt_medium_template_view.xml
+++ b/nativetemplates/src/main/res/layout/gnt_medium_template_view.xml
@@ -145,7 +145,7 @@
                   android:id="@+id/rating_bar"
                   android:background="@color/gnt_white"
                   android:layout_width="wrap_content"
-                  android:layout_height="match_parent"
+                  android:layout_height="wrap_content"
                   android:textSize="@dimen/gnt_text_size_small"
                   android:textColor="@color/gnt_gray"
                   android:numStars="5"
@@ -158,7 +158,8 @@
                   app:layout_constraintBottom_toBottomOf="parent"
                   app:layout_constraintEnd_toEndOf="parent"
                   app:layout_constraintStart_toEndOf="@id/ad_notification_view"
-                  app:layout_constraintTop_toTopOf="parent">
+                  app:layout_constraintTop_toTopOf="parent"
+                  style="?android:attr/ratingBarStyleSmall">
 
               </RatingBar>
               <TextView

--- a/nativetemplates/src/main/res/layout/gnt_small_template_view.xml
+++ b/nativetemplates/src/main/res/layout/gnt_small_template_view.xml
@@ -123,7 +123,7 @@
                 android:id="@+id/rating_bar"
                 android:background="@color/gnt_white"
                 android:layout_width="wrap_content"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:textSize="@dimen/gnt_text_size_small"
                 android:textColor="@color/gnt_gray"
                 android:numStars="5"
@@ -136,7 +136,8 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/ad_notification_view"
-                app:layout_constraintTop_toTopOf="parent">
+                app:layout_constraintTop_toTopOf="parent"
+                style="?android:attr/ratingBarStyleSmall">
 
             </RatingBar>
             <TextView


### PR DESCRIPTION
Updates RatingBar to small style and height to wrap content (https://github.com/googleads/googleads-mobile-android-native-templates/issues/25).

Current medium layout: https://screenshot.googleplex.com/6RJXHiS5qWFQHJk
Current small layout: https://screenshot.googleplex.com/9gAqBtnjUnmbsV3

Updated medium layout: https://screenshot.googleplex.com/AYKWq4bFBR4tDa9
Updated small layout: https://screenshot.googleplex.com/8YDetgNUUHNUAi6

Also adds error prone dependency (https://github.com/googleads/googleads-mobile-android-native-templates/issues/31)